### PR TITLE
修正《突出显示》 在其他控件上启用“展示” 小节的错误

### DIFF
--- a/windows-apps-src/design/style/reveal.md
+++ b/windows-apps-src/design/style/reveal.md
@@ -78,7 +78,7 @@ ms.locfileid: "66370435"
 
 | 控件名称   | 资源名称 |
 |----------|:-------------:|
-| 按钮 |  ButtonRevealStyle |
+| Button |  ButtonRevealStyle |
 | ToggleButton | ToggleButtonRevealStyle |
 | RepeatButton | RepeatButtonRevealStyle |
 | AppBarButton | AppBarButtonRevealStyle |
@@ -88,7 +88,7 @@ ms.locfileid: "66370435"
 若要应用这些样式，只需设置控件的[样式](/uwp/api/Windows.UI.Xaml.Style)属性：
 
 ```xaml
-<Button Content="Button Content" Style="{StaticResource ButtonRevealStyle}"/>
+<Button Content="Button Content" Style="{ThemeResource ButtonRevealStyle}"/>
 ```
 
 ### <a name="reveal-in-themes"></a>主题中的展示


### PR DESCRIPTION
控件名称 Button 不需要翻译
示例中应该使用 ThemeResource 而不是 StaticResource